### PR TITLE
change script return value to SA-MP server return code

### DIFF
--- a/samp_server_cli.py
+++ b/samp_server_cli.py
@@ -277,7 +277,7 @@ class Server:
         return 1
       else:
         timeout_timer.cancel()
-    return 0
+    return process.returncode
 
 def generate_password(size=10,
                       chars=string.ascii_letters + string.digits):


### PR DESCRIPTION
I need this for TravisCI, because your script always returns zero, even if the SA-MP server can't find any gamemode or plugin.

current result (without PR): https://travis-ci.org/pBlueG/SA-MP-MySQL/jobs/84667410#L531
desired result (with PR): https://travis-ci.org/pBlueG/SA-MP-MySQL/jobs/84758167#L531